### PR TITLE
Add pytest-neon plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Pytest Quick Start Guide by Bruno Oliveira - [Packt (publisher)](https://www.pac
 
 [pytest-monitor](https://github.com/CFMTech/pytest-monitor) - Pytest-monitor is a pytest plugin designed for analyzing resource usage.
 
+[pytest-neon](https://github.com/ZainRizvi/pytest-neon) - Pytest plugin for Neon database branch isolation. Each test gets its own isolated database state via Neon's instant branching.
+
 [pytest-opentelemetry](https://github.com/chrisguidry/pytest-opentelemetry) - Instruments your pytest runs, exporting the spans and timing via OpenTelemetry.
 
 [pytest-picked](https://pypi.org/project/pytest-picked/) - Run tests related to changes detected by version control (e.g. run all tests in test files with unstaged changes).


### PR DESCRIPTION
Adds pytest-neon, a plugin for Neon database branch isolation in tests.

Each test gets its own isolated database state via Neon's instant branching and reset. Useful for integration tests against real Postgres without Docker.

Hope it's cool to add my own plugin here. Let me know if you want me to do anything differently!