### PR TITLE
Add Python Developer Tooling Handbook pytest pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ Pytest Quick Start Guide by Bruno Oliveira - [Packt (publisher)](https://www.pac
 
 [A checklist of best practices to speed up your pytest suite](https://github.com/zupo/awesome-pytest-speedup)
 
+[Setting Up Testing with pytest and uv](https://pydevtools.com/handbook/tutorial/setting-up-testing-with-pytest-and-uv/) - A tutorial on setting up a Python testing workflow with pytest and uv.
+
+[How to Run Tests in Parallel with pytest-xdist](https://pydevtools.com/handbook/how-to/how-to-run-tests-in-parallel-with-pytest-xdist/) - A guide to parallelizing your test suite using pytest-xdist.
+
+[pytest Reference](https://pydevtools.com/handbook/reference/pytest/) - A reference page covering pytest's key features, pros, cons, and ecosystem.
+
 ## Presentations
 
 [Adopt-a-pytest](https://www.youtube.com/watch?v=0BzXV0J3-v8) - [slides](https://speakerdeck.com/daneah/adopt-a-pytest)


### PR DESCRIPTION
Adds three pages from the [Python Developer Tooling Handbook](https://pydevtools.com) (pydevtools.com) to the Articles section:

- **[Setting Up Testing with pytest and uv](https://pydevtools.com/handbook/tutorial/setting-up-testing-with-pytest-and-uv/)** - A tutorial walking through setting up a Python testing workflow with pytest and uv.
- **[How to Run Tests in Parallel with pytest-xdist](https://pydevtools.com/handbook/how-to/how-to-run-tests-in-parallel-with-pytest-xdist/)** - A practical guide to parallelizing test suites using pytest-xdist.
- **[pytest Reference](https://pydevtools.com/handbook/reference/pytest/)** - A reference page covering pytest's key features, pros, cons, and ecosystem.

The handbook is a free resource documenting Python development tools and practices, following the Diataxis documentation framework.