### PR TITLE
Add postman2pytest to Code samples and projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Pytest Quick Start Guide by Bruno Oliveira - [Packt (publisher)](https://www.pac
 
 [Requests - Python HTTP Requests for Humans™ and Pytest](https://github.com/requests/requests/tree/master/tests)
 
+[postman2pytest](https://github.com/golikovichev/postman2pytest) - Convert Postman v2 collections to runnable pytest test suites with parametrised fixtures and auth handling.
+
 ## Plugins
 
 [Plugin List](https://docs.pytest.org/en/latest/reference/plugin_list.html) - PyPI projects that match “pytest-*” are considered plugins and are listed automatically. Packages classified as inactive are excluded. This list contains 865 plugins.


### PR DESCRIPTION
Adds `postman2pytest` to the Code samples and projects section.

`postman2pytest` is an open-source CLI that converts Postman v2 collections into runnable pytest test suites. It handles auth headers, body schemas, and environment variables, and emits parametrised pytest code with fixtures.

- Repo: https://github.com/golikovichev/postman2pytest
- PyPI: https://pypi.org/project/postman2pytest/
- License: MIT
- CI: passing on Python 3.10-3.12

Happy to adjust placement or wording if a different section fits better.