### PR TITLE
Add pytest-mrt to Plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Pytest Quick Start Guide by Bruno Oliveira - [Packt (publisher)](https://www.pac
 
 [pytest-neon](https://github.com/ZainRizvi/pytest-neon) - Pytest plugin for Neon database branch isolation. Each test gets its own isolated database state via Neon's instant branching.
 
+[pytest-mrt](https://github.com/croc100/pytest-mrt) - pytest plugin and CLI for Alembic and Django migration rollback safety testing. Detects unsafe migration patterns (44 static analysis rules) and verifies every migration is reversible via dynamic up/down/up cycle testing.
+
 [pytest-opentelemetry](https://github.com/chrisguidry/pytest-opentelemetry) - Instruments your pytest runs, exporting the spans and timing via OpenTelemetry.
 
 [pytest-picked](https://pypi.org/project/pytest-picked/) - Run tests related to changes detected by version control (e.g. run all tests in test files with unstaged changes).


### PR DESCRIPTION
I've been bitten a few times by migrations that applied cleanly but failed on rollback — sometimes silently, sometimes with data loss. Built pytest-mrt to catch these before they hit production.

It does two things: static analysis on migration files (44 patterns, no database needed), and dynamic verification that actually runs the up/down/up cycle against a real database and checks that schema and data survive the round trip. Works with both Alembic and Django.

- PyPI: https://pypi.org/project/pytest-mrt/
- MIT, actively maintained