### PR TITLE
Add allure-pytest-auto to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Pytest Quick Start Guide by Bruno Oliveira - [Packt (publisher)](https://www.pac
 
 [AFLuent](https://github.com/AFLuent/AFLuent) - Automated fault localization tool built as a Pytest plugin. It's triggered when one or more test case fails causing it to generate a ranking of suspicious statements where the cause of the fault could possibly be.
 
+[allure-pytest-auto](https://github.com/sjvaidya/allure-pytest-auto) - Pytest plugin that automates Allure reporting: timestamped reports (no more overwrites), automatic environment.properties generation, and auto-opening the report — built on top of allure-pytest plugin.
+
 [pyfakefs](https://github.com/pytest-dev/pyfakefs) - Provides a fake file system that mocks the Python file system modules.
 
 [pytest-bdd](https://pypi.python.org/pypi/pytest-bdd) - pytest-bdd implements a subset of the Gherkin language to enable automating project requirements testing and to facilitate behavioral driven development.


### PR DESCRIPTION
Adds allure-pytest-auto (https://github.com/sjvaidya/allure-pytest-auto) to the list — a pytest plugin, built on top of allure-pytest, that automates Allure reporting: timestamped reports (no more overwrites), automatic environment.properties generation, and auto-opening the report.

I'm the author/maintainer of this plugin.